### PR TITLE
app ctrl server restart

### DIFF
--- a/src/app_ctrl_bootstrap.erl
+++ b/src/app_ctrl_bootstrap.erl
@@ -9,7 +9,17 @@
         , removing_handler/1
         ]).
 
+-export([ update_server_pid/1 ]).
+
 -include_lib("kernel/include/logger.hrl").
+
+%%% ======================================================================
+%%% State updates
+
+update_server_pid(Pid) when is_pid(Pid) ->
+    {ok, #{config := HConf}} = logger:get_handler_config(app_ctrl),
+    logger:update_handler_config(
+      app_ctrl, config, HConf#{app_ctrl_server => Pid}).
 
 %%% ======================================================================
 %%% Logger callbacks


### PR DESCRIPTION
If the app_ctrl app is stopped and restarted, or if the app_ctrl_server crashes (heaven forbid), the proxy needs to detect that the logger bootstrap handler has a stale pid, restart the server and update the handler config. That last step is mostly a matter of aesthetics.