### PR TITLE
Fix bad return value from handle_info

### DIFF
--- a/src/app_ctrl_server.erl
+++ b/src/app_ctrl_server.erl
@@ -235,7 +235,7 @@ handle_info({timeout, TRef, {awaiting_stable, From}}, #st{pending_stable = Pend}
         {value, {From, _}, Pend1} ->
             case is_stable(St) of
                 true ->
-                    notify_pending({ok, St#st.mode}, St#st{stable = true});
+                    {noreply, notify_pending({ok, St#st.mode}, St#st{stable = true})};
                 {false, Outstanding} ->
                     gen_server:reply(From, {timeout, Outstanding}),
                     {noreply, St#st{pending_stable = Pend1}}


### PR DESCRIPTION
Fixing this problem:
```erlang
12:06:34.902 [error] gen_server app_ctrl_server terminated with reason: bad return value: {st,[{app_ctrl,<0.1274.0>},{inets,<0.1275.0>},{ranch,<0.1276.0>},{exometer_core,<0.1277.0>},{jobs,<0.1278.0>},{gproc,<0.1279.0>},{aecore,<0.1280.0>},{goldrush,<0.1281.0>},{ssl,<0.1282.0>},{lager,<0.1283.0>},{setup,<0.1284.0>},{aechannel,<0.1285.0>},{yamerl,<0.1286.0>},{mnesia,<0.1287.0>},{cowboy,<0.1288.0>},{mnesia_rocksdb,<0.1289.0>},{runtime_tools,<0.1290.0>},{sasl,<0.1291.0>},{folsom,<0.1292.0>},{aeutils,<0.1293.0>},{aesync,<0.1294.0>},{aehttp,<0.1295.0>},{aemon,<0.1296.0>},{aestratum,<0.1297.0>}],...}
12:06:34.903 [error] CRASH REPORT Process app_ctrl_server with 15 neighbours exited with reason: bad return value: {st,[{app_ctrl,<0.1274.0>},{inets,<0.1275.0>},{ranch,<0.1276.0>},{exometer_core,<0.1277.0>},{jobs,<0.1278.0>},{gproc,<0.1279.0>},{aecore,<0.1280.0>},{goldrush,<0.1281.0>},{ssl,<0.1282.0>},{lager,<0.1283.0>},{setup,<0.1284.0>},{aechannel,<0.1285.0>},{yamerl,<0.1286.0>},{mnesia,<0.1287.0>},{cowboy,<0.1288.0>},{mnesia_rocksdb,<0.1289.0>},{runtime_tools,<0.1290.0>},{sasl,<0.1291.0>},{folsom,<0.1292.0>},{aeutils,<0.1293.0>},{aesync,<0.1294.0>},{aehttp,<0.1295.0>},{aemon,<0.1296.0>},{aestratum,<0.1297.0>}],...} in gen_server:handle_common_reply/8 line 815
```